### PR TITLE
Fix Uninstall Script

### DIFF
--- a/scripts/fpp_uninstall.sh
+++ b/scripts/fpp_uninstall.sh
@@ -2,3 +2,6 @@
 
 # fpp-brightness uninstall script
 
+# force restart after uninstall
+. ${FPPDIR}/scripts/common
+setSetting restartFlag 1


### PR DESCRIPTION
Sets FPPD restart required flag after uninstallation to ensure everything is cleared/removed.

An FPPD restart is necessary to ensure that remote/multisync devices don't continue to receive brightness updates from master even after brightness plugin is uninstalled (but not rebooted/restarted).