### PR TITLE
fix: Restrict Brightness to 0-200 and report an error when out of range

### DIFF
--- a/src/FPPBrightness.cpp
+++ b/src/FPPBrightness.cpp
@@ -69,6 +69,14 @@ public:
             {
                 brightness = std::atoi(args[0].c_str());
             }
+            if (brightness > 200)
+            {
+                return std::make_unique<Command::ErrorResult>("Brightness cannot be set above 200");
+            }
+            if (brightness < 0)
+            {
+                return std::make_unique<Command::ErrorResult>("Brightness cannot be set below 0");
+            }
             plugin->resetFade();
             plugin->setBrightness(brightness, false);
             return std::make_unique<Command::Result>("Brightness Set");
@@ -89,6 +97,14 @@ public:
             if (args.size() >= 1)
             {
                 adjust = std::stoi(args[0]);
+            }
+            if (plugin->brightness + adjust > 200)
+            {
+                return std::make_unique<Command::ErrorResult>("Brightness cannot be adjusted above 200");
+            }
+            if (plugin->brightness + adjust < 0)
+            {
+                return std::make_unique<Command::ErrorResult>("Brightness cannot be adjusted below 0");
             }
             plugin->resetFade();
             plugin->setBrightness(plugin->brightness + adjust, false);
@@ -116,6 +132,14 @@ public:
             if (args.size() >= 2)
             {
                 duration = std::stoi(args[1]);
+            }
+            if (newBrightness > 200)
+            {
+                return std::make_unique<Command::ErrorResult>("Brightness cannot be faded above 200");
+            }
+            if (newBrightness < 0)
+            {
+                return std::make_unique<Command::ErrorResult>("Brightness cannot be faded below 0");
             }
             plugin->fade(newBrightness, duration);
             return std::make_unique<Command::Result>("Brightness Fade");
@@ -425,6 +449,14 @@ public:
 
     void setBrightness(int i, bool sendSync = true)
     {
+        if (i > 200)
+        {
+            i = 200;
+        }
+        if (i < 0)
+        {
+            i = 0;
+        }
         if (brightness != i)
         {
             brightness = i;


### PR DESCRIPTION
# fix: Restrict Brightness to 0-200 and report an error when out of range

## Summary

Prevents the FPP Brightness plugin from accepting brightness values above **200** for the `Brightness`, `Brightness Adjust`, and `Brightness Fade` commands. Passed out-of-range values now fail the command with a descriptive error instead of being allowed to run (and being silently clamped).

## Motivation

Brightness values above 200 are not valid for this plugin, yet the FPP Command dialog still allowed entering values such as `300`. Previously the command executed and returned a green "command ran" success notification even when the value was rejected. This change:

- Rejects any brightness value above `200` (and below `0`).
- Ensures the FPP command dialog reports a failure/error (rather than a success) when an out-of-range value is entered.

## Changes

All changes are in `src/FPPBrightness.cpp`:

1. **`setBrightness()`** — added clamping so the value is always confined to `0-200` regardless of the entry point (commands, REST API, or MQTT).

2. **`SetBrightnessCommand::run()`** (`Brightness`)
   - Returns `Command::ErrorResult` if the entered value is above `200` or below `0`.

3. **`AdjustBrightnessCommand::run()`** (`Brightness Adjust`)
   - Returns `Command::ErrorResult` if `current + adjust` would exceed `200` or fall below `0`.

4. **`FadeBrightnessCommand::run()`** (`Brightness Fade`)
   - Returns `Command::ErrorResult` if the end brightness is above `200` or below `0`.

Returning `Command::ErrorResult` (instead of the plain `Command::Result`) marks the command as failed, so FPP surfaces the message as an error instead of a success notification.

## Additional Comments

This PR closes #7.